### PR TITLE
Fix the fonts.conf file path

### DIFF
--- a/fontmatrix.1
+++ b/fontmatrix.1
@@ -53,10 +53,10 @@ A few important environment variables from other programs are summarised here fo
 User preferences are stored in $HOME/.fontmatrix/ on Unix or Linux. Most other paths are configurable from the Fontmatrix preferences. 
 .B $HOME/.fonts/
 .TP 
-.B $HOME/.fonts.conf
+.B $HOME/.config/fontconfig/fonts.conf
 .TP 
 .B /etc/fonts
-Fontconfig, the library used by Fontmatrix to locate fonts, is normally configured with files in /etc/fonts, mainly /etc/fonts/fonts.conf and /etc/fonts/local.conf . It may also use a config file $HOME/.fonts.conf and fonts in $HOME/.fonts/ . See fonts.conf(5) and the fontconfig documentation for more information. Note that Fontmatrix may also use its internal font path to locate more fonts \- see the Preferences dialog and fontmatrix help.
+Fontconfig, the library used by Fontmatrix to locate fonts, is normally configured with files in /etc/fonts, mainly /etc/fonts/fonts.conf and /etc/fonts/local.conf . It may also use a config file $HOME/.config/fontconfig/fonts.conf and fonts in $HOME/.fonts/ . See fonts.conf(5) and the fontconfig documentation for more information. Note that Fontmatrix may also use its internal font path to locate more fonts \- see the Preferences dialog and fontmatrix help.
 .SH "RELATED SOFTWARE AND AFFILIATES"
 Scribus \- http://www.scribus.net
 

--- a/src/fmactivate.cpp
+++ b/src/fmactivate.cpp
@@ -285,7 +285,7 @@ void FMActivate::activate(QList< FontItem * > fitList, bool act)
 bool FMActivate::addFcReject(const QString & path)
 {
 #ifdef HAVE_FONTCONFIG
-	QFile fcfile ( QDir::homePath() + "/.fonts.conf" );
+	QFile fcfile ( QDir::homePath() + "/.config/fontconfig/fonts.conf" );
 	if ( !fcfile.open ( QFile::ReadWrite ) )
 	{
 		qWarning()<<"Cannot open"<< fcfile.fileName();
@@ -380,7 +380,7 @@ bool FMActivate::addFcReject(const QString & path)
 bool FMActivate::remFcReject(const QString & path)
 {
 #ifdef HAVE_FONTCONFIG
-	QFile fcfile ( QDir::homePath() + "/.fonts.conf" );
+	QFile fcfile ( QDir::homePath() + "/.config/fontconfig/fonts.conf" );
 	if ( !fcfile.open ( QFile::ReadWrite ) )
 	{
 		return false;

--- a/src/fmactivate.h
+++ b/src/fmactivate.h
@@ -52,7 +52,7 @@ class FMActivate : public QObject
 		
 	private:
 		/*
-		Add and Remove fonts in ~/.fonts.conf
+		Add and Remove fonts in ~/.config/fontconfig/fonts.conf
 		with <selecfont><rejectfont><glob> sequence
 		*/
 		bool addFcReject(const QString& path);

--- a/src/typotek.cpp
+++ b/src/typotek.cpp
@@ -1093,7 +1093,7 @@ void typotek::checkOwnDir()
 void typotek::addFcDirItem(const QString & dirPath)
 {
 #ifdef HAVE_FONTCONFIG
-	QFile fcfile ( QDir::homePath() + "/.fonts.conf" );
+	QFile fcfile ( QDir::homePath() + "/.config/fontconfig/fonts.conf" );
 	if ( !fcfile.open ( QFile::ReadWrite ) )
 	{
 		return;


### PR DESCRIPTION
Location for ~/.fonts.conf is now moved to ~/.config/fontconfig/fonts.conf 
