### PR TITLE
Fix preview-word so it isn't ignored.

### DIFF
--- a/src/typotek.cpp
+++ b/src/typotek.cpp
@@ -2392,7 +2392,7 @@ QString typotek::word(FontItem * item, const QString& alt)
 	if(item)
 	{
 		QString word(m_theWord);
-		if(!alt.isEmpty())
+		if(word.isEmpty() && !alt.isEmpty())
 			word = alt;
 		word.replace("<name>", item->fancyName());
 		word.replace("<family>", item->family());


### PR DESCRIPTION
Fixes Display Preview Word for custom text on the font labels. See, for example, https://bugs.launchpad.net/ubuntu/+source/fontmatrix/+bug/1019419 (Note that the height issue for subtitles hasn't been touched in this commit).
