### PR TITLE
Make fontmatrix compile on ARM platforms

### DIFF
--- a/src/fminfodisplay.cpp
+++ b/src/fminfodisplay.cpp
@@ -151,7 +151,8 @@ QString FMInfoDisplay::writeSVGPreview(FontItem * font)
 				GlyphToSVGHelper gtsh ( gpi->path(), tf );
 				svg += gtsh.getSVGPath() + "\n";
 				horOffset += gpi->data(GLYPH_DATA_HADVANCE).toDouble() * scaleFactor;
-				maxHeight = qMax ( gtsh.getRect().height(), maxHeight );
+				/* cast gtsh.height from qreal (float on ARM) to double so qMax can be done */
+				maxHeight = qMax ( (double) gtsh.getRect().height(), maxHeight );
 				tf.translate( gpi->data(GLYPH_DATA_HADVANCE).toDouble()  * scaleFactor,0 );
 				delete gpi;
 			}


### PR DESCRIPTION
On ARM qreal is float instead of double
- http://doc.qt.io/qt-4.8/qtglobal.html#qreal-typedef
so, in fminfodisplay.cpp, a cast is needed from qfloat to double  in
FMInfoDisplay::writeSVGPreview for a qMax test.

This was blocking for compilation:

[  6%] Building CXX object src/CMakeFiles/fontmatrix.dir/fminfodisplay.cpp.o
/home/alarm/arch/fontmatrix/fontmatrix-git/src/fontmatrix/src/fminfodisplay.cpp: In member function 'QString FMInfoDisplay::writeSVGPreview(FontItem*)':
/home/alarm/arch/fontmatrix/fontmatrix-git/src/fontmatrix/src/fminfodisplay.cpp:154:59: error: no matching function for call to 'qMax(qreal, double&)'
     maxHeight = qMax ( gtsh.getRect().height(), maxHeight );
                                                           ^
