### PR TITLE
Fix no return statement in the non-void function (according g++8)

### DIFF
--- a/src/chartwidget.cpp
+++ b/src/chartwidget.cpp
@@ -127,7 +127,7 @@ QString ChartWidget::currentBlock()
 	return ui->uniPlaneCombo->currentText();
 }
 
-bool ChartWidget::selectBlock(const QString &uname)
+void ChartWidget::selectBlock(const QString &uname)
 {
 	int idx(ui->uniPlaneCombo->findText(uname));
 	if(idx < 0)

--- a/src/chartwidget.h
+++ b/src/chartwidget.h
@@ -41,7 +41,7 @@ public:
     ~ChartWidget();
 
     QString currentBlock();
-    bool selectBlock(const QString& uname);
+    void selectBlock(const QString& uname);
 
 protected:
     void changeEvent(QEvent *e);

--- a/src/samplewidget.h
+++ b/src/samplewidget.h
@@ -98,8 +98,8 @@ public:
 		QByteArray toByteArray() const;
 		State fromByteArray(QByteArray b);
 
-	private:
-		State operator= (const State&){}
+	// private:
+		// State operator= (const State&){}
 	};
 
 	static const QString Name;

--- a/src/tagswidget_listmodel.cpp
+++ b/src/tagswidget_listmodel.cpp
@@ -164,6 +164,8 @@ QModelIndex TagsWidget_ListModel::addTag()
 			return index(i);
 	}
 
+	return QModelIndex();
+
 }
 
 


### PR DESCRIPTION
If the function is non-void, but no return, then when building with gcc8-c++, an incorrect assembler code is generated that falls in run-time. A more detailed description can be found here http://bugs.altlinux.org/36038.