### PR TITLE
Build fontmatrix on Travis CI, create and build AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - sudo apt-get -y build-dep fontmatrix
 
 script:
-  - cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DWANT_PYTHONQT:bool=false -DWANT_ICU:bool=false -DWANT_HARFBUZZ:bool=false 
+  - cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DWANT_PYTHONQT:bool=false -DWANT_ICU:bool=true -DWANT_HARFBUZZ:bool=true 
   - make -j$(nproc)
   - make DESTDIR=appdir -j$(nproc) install ; find appdir/
   - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+install:
+  - sudo apt-get -y install libqt4-sql-sqlite python-dev libicu-dev
+  - sudo apt-get -y build-dep fontmatrix
+
+script:
+  - qmake CONFIG+=release PREFIX=/usr -DWANT_PYTHONQT:bool=false -DWANT_ICU:bool=false -DWANT_HARFBUZZ:bool=false 
+  - make -j$(nproc)
+  - make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
+
+after_success:
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh Fontmatrix*.AppImage*
+  
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - sudo apt-get -y build-dep fontmatrix
 
 script:
-  - cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DWANT_PYTHONQT:bool=false -DWANT_ICU:bool=true -DWANT_HARFBUZZ:bool=true 
+  - cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DWANT_PYTHONQT:bool=false -DWANT_ICU:bool=false -DWANT_HARFBUZZ:bool=true 
   - make -j$(nproc)
   - make DESTDIR=appdir -j$(nproc) install ; find appdir/
   - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ install:
   - sudo apt-get -y build-dep fontmatrix
 
 script:
-  - qmake CONFIG+=release PREFIX=/usr -DWANT_PYTHONQT:bool=false -DWANT_ICU:bool=false -DWANT_HARFBUZZ:bool=false 
+  - cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DWANT_PYTHONQT:bool=false -DWANT_ICU:bool=false -DWANT_HARFBUZZ:bool=false 
   - make -j$(nproc)
-  - make INSTALL_ROOT=appdir -j$(nproc) install ; find appdir/
+  - make DESTDIR=appdir -j$(nproc) install ; find appdir/
   - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
   - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
   - ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage

--- a/src/messages/about_people.html
+++ b/src/messages/about_people.html
@@ -76,5 +76,11 @@ color:white;
 	<div class="mail">pavelfric@seznam.cz</div>
 </div>
 
+<div class="someone"><!--Simon -->
+	<div class="name">Simon Peter</div>
+	<div class="whathedoes">AppImage packaging</div>
+	<div class="mail">probono@puredarwin.org</div>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Here is an overviev of Libre Graphics projects that are already distributing upstream-provided, official AppImages: https://github.com/AppImage/AppImageKit/wiki/Libre-Graphics-Suite

__PLEASE NOTE:__ For this to work, you need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.
If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.